### PR TITLE
solve -> solve! (for JuliaVariables)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ DataStructures = "^0.17"
 JuliaVariables = "^0.2"
 MLStyle = "^0.3.1"
 julia = "1"
-JuliaVariables = "0.1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/GeneralizedGenerated.jl
+++ b/src/GeneralizedGenerated.jl
@@ -19,7 +19,7 @@ end
 function mk_function(mod::Module, ex)
     ex = macroexpand(mod, ex)
     ex = simplify_ex(ex)
-    ex = solve(ex)
+    ex = solve!(ex)
     fn = closure_conv(mod, ex)
     if !(fn isa RuntimeFn)
         error("Expect an unnamed function expression. ")

--- a/src/closure_conv.jl
+++ b/src/closure_conv.jl
@@ -121,7 +121,7 @@ function gg(compmod::Module, runmod::Any, source::Union{Nothing, LineNumberNode}
         let ast = Base.macroexpand($compmod, $body),
             fake_ast = Base.Expr(:function, $(QuoteNode(pseudo_head)), ast),
             fake_ast = $simplify_ex(fake_ast),
-            fake_ast = $solve(fake_ast),
+            fake_ast = $solve!(fake_ast),
             fake_fn = $closure_conv($(QuoteNode(runmod)), fake_ast)
             $from_type($_get_body(fake_fn))
         end


### PR DESCRIPTION
This PR adds just two characters, a `!` after each `solve`, in order to be consistent with the recent change to JuliaVariables