### PR TITLE
Make RuntimeFn and Closure <: Function

### DIFF
--- a/slides/GG.md
+++ b/slides/GG.md
@@ -162,7 +162,7 @@ free variables, if we presume
 we can introduce a structure(`Closure`) to represent a closure:
 
 ```julia
-struct Closure{F, Free}
+struct Closure{F, Free} <: Function
     frees :: Free
 end
 
@@ -221,7 +221,7 @@ procedures:
   we generate a closure structure with `frees`:
 
 ```julia
-struct Closure{F, Free}
+struct Closure{F, Free} <: Function
     frees :: Free
 end
 
@@ -354,7 +354,7 @@ However, we propose a type to achieve generating non-closure functions
 in runtime:
 
 ```julia
-struct RuntimeFn{Args, Kwargs, Body} end
+struct RuntimeFn{Args, Kwargs, Body} <: Function end
 ```
 
 where both `Args` and `Kwargs` are typeable representations of

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -1,4 +1,4 @@
-struct Closure{F,Free}
+struct Closure{F,Free} <: Function
     frees::Free
 end
 

--- a/src/ngg/runtime_fns.jl
+++ b/src/ngg/runtime_fns.jl
@@ -1,4 +1,4 @@
-struct RuntimeFn{Args,Kwargs,Body,Name} end
+struct RuntimeFn{Args,Kwargs,Body,Name} <: Function end
 struct Unset end
 
 Base.show(io::IO, rtfn::RuntimeFn{Args,Kwargs,Body,Name}) where {Args,Kwargs,Body,Name} =


### PR DESCRIPTION
This PR makes `RuntimeFn <: Function` and `Closure <: Function`.

Possible concerns:
- Most functions are singletons, i.e. they're completely determined by their type. This is the case for `RuntimeFn`, but not for `Closure`. The behavior of a `Closure` depends on its `frees` field, which is typically only known at runtime.
- Many `Function`s satisfy `f == typeof(f).instance`. That's not the case here. On the other hand, (1) it's not clear how important this behavior is, and (2) if it is important, it could easily be added by adding a `getproperty` method.

I'm starting to second-guess this now, think I should ask around a little before we merge